### PR TITLE
bugfix for empty arrays in kilt definitions

### DIFF
--- a/pkg/hocon/build.go
+++ b/pkg/hocon/build.go
@@ -13,7 +13,13 @@ func extractBuild(config *configuration.Config) (*kilt.Build, error) {
 
 	b.Image = config.GetString("build.image")
 	b.EntryPoint = config.GetStringList("build.entry_point")
+	if b.EntryPoint == nil {
+		b.EntryPoint = make([]string, 0)
+	}
 	b.Command = config.GetStringList("build.command")
+	if b.Command == nil {
+		b.Command = make([]string, 0)
+	}
 
 	b.EnvironmentVariables = extractToStringMap(config, "build.environment_variables")
 

--- a/pkg/hocon/hocon.go
+++ b/pkg/hocon/hocon.go
@@ -46,12 +46,9 @@ func (k *KiltHocon) prepareFullStringConfig(info *kilt.TargetInfo) (*configurati
 		return nil, fmt.Errorf("could not serialize info: %w", err)
 	}
 
-	fmt.Println("ANTANI", string(rawVars), "ANTANI")
 	configString := "original:" + string(rawVars) + "\n" +
 		"config:" + k.config + "\n" +
 		defaults + k.definition
-
-	fmt.Println("ANTANI", string(configString), "ANTANI")
 
 	return configuration.ParseString(configString), nil
 }

--- a/runtimes/cloudformation/cfnpatcher/entrypointinfo.go
+++ b/runtimes/cloudformation/cfnpatcher/entrypointinfo.go
@@ -17,7 +17,7 @@ func getConfigFromRepository(image string) (*PartialImageConfig,error) {
 
 	res, err := crane.Config(image)
 	if err != nil {
-		return nil, fmt.Errorf("could not get detauls about image %s: %w", image, err)
+		return nil, fmt.Errorf("could not get defaults about image %s: %w", image, err)
 	}
 	cont, err := gabs.ParseJSON(res)
 	if err != nil {

--- a/runtimes/cloudformation/cmd/handler/main.go
+++ b/runtimes/cloudformation/cmd/handler/main.go
@@ -40,6 +40,7 @@ func HandleRequest(configuration *cfnpatcher.Configuration, ctx context.Context,
 	if err != nil {
 		return MacroOutput{event.RequestID, "failure", result}, err
 	}
+	log.Info().Str("template", string(result)).Msg("processing complete")
 	return MacroOutput{event.RequestID, "success", result}, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When using empty arrays in the kilt definition hocon library interprets them as nil in go, making CFN complain
