### PR TITLE
Fix duplicate entry point during image command and entry point detection

### DIFF
--- a/runtimes/cloudformation/.gitignore
+++ b/runtimes/cloudformation/.gitignore
@@ -1,3 +1,4 @@
 /kilt.zip
 /cmd/handler/handler
 /cmd/cfn-apply-kilt/cfn-apply-kilt
+/cmd/cfn-image-info/cfn-image-info

--- a/runtimes/cloudformation/cfnpatcher/entrypointinfo.go
+++ b/runtimes/cloudformation/cfnpatcher/entrypointinfo.go
@@ -12,7 +12,7 @@ type PartialImageConfig struct {
 	Command []string
 }
 
-func getConfigFromRepository(image string) (*PartialImageConfig,error) {
+func GetConfigFromRepository(image string) (*PartialImageConfig,error) {
 	ic := new(PartialImageConfig)
 
 	res, err := crane.Config(image)
@@ -36,7 +36,7 @@ func getConfigFromRepository(image string) (*PartialImageConfig,error) {
 	if cont.Exists("config", "Cmd") {
 		for _, v := range cont.S("config", "Cmd").Children() {
 			if a, ok := v.Data().(string); ok {
-				ic.Command = append(ic.Entrypoint, a)
+				ic.Command = append(ic.Command, a)
 			}
 		}
 	}else{

--- a/runtimes/cloudformation/cfnpatcher/template.go
+++ b/runtimes/cloudformation/cfnpatcher/template.go
@@ -18,7 +18,7 @@ func extractContainerInfo(group *gabs.Container, groupName string, container *ga
 	if container.Exists("Image") {
 		info.Image = container.S("Image").Data().(string)
 		os.Setenv("HOME", "/tmp")  // crane requires $HOME variable
-		repoInfo, err := getConfigFromRepository(info.Image)
+		repoInfo, err := GetConfigFromRepository(info.Image)
 		if err != nil {
 			log.Warn().Str("image", info.Image).Err(err).Msg("could not retrieve metadata from repository")
 		}else{

--- a/runtimes/cloudformation/cmd/cfn-image-info/main.go
+++ b/runtimes/cloudformation/cmd/cfn-image-info/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	"github.com/google/go-containerregistry/pkg/crane"
+	"fmt"
 	"os"
+
+	"github.com/falcosecurity/kilt/runtimes/cloudformation/cfnpatcher"
 )
 
 func main() {
@@ -10,9 +12,10 @@ func main() {
 		println("needs 1 argument: image")
 		return
 	}
-	res, err := crane.Config(os.Args[1])
+
+	res, err := cfnpatcher.GetConfigFromRepository(os.Args[1])
 	if err != nil {
 		panic(err)
 	}
-	println(string(res))
+	fmt.Printf("%+v\n", res)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

/area runtimes/cloudformation

**What this PR does / why we need it**:

detection of command repeats entry point

```release-note
NONE
```