### PR TITLE
chore(.github): remove release-note block for kilt

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -54,16 +54,4 @@ Fixes #
 
 **Special notes for your reviewer**:
 
-**Does this PR introduce a user-facing change?**:
 
-<!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below.
-If the PR requires additional action from users switching to the new release, prepend the string "action required:".
-For example, `action required: change the API interface of the rule engine`.
--->
-
-```release-note
-
-```


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>



**What type of PR is this?**



/kind documentation



**Any specific area of the project related to this PR?**

NONE

**What this PR does / why we need it**:

Remove the release-note block from the PR template since kilt uses goreleaser and the commit messages to generate the CHANGELOG.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

Pairs with https://github.com/falcosecurity/test-infra/pull/301

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```
