### PR TITLE
Build binaries with CGO_ENABLED=0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /utilities/launcher/launcher
 /utilities/logshipper/logshipper
 /utilities/waitforever/waitforever
+/utilities/debug-bridge/debug-bridge
+
 /installer/artifacts
 /installer/kilt
 /installer/cmd/kilt-installer/pkged.go

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,7 +1,7 @@
 installer: deps
 	go get github.com/markbates/pkger/cmd/pkger
 	pkger -o cmd/kilt-installer
-	cd cmd/kilt-installer && go build .
+	cd cmd/kilt-installer && CGO_ENABLED=0 go build .
 	@cp cmd/kilt-installer/kilt-installer kilt
 
 deps: artifacts/kilt-cfn-macro.zip cmd/kilt-installer/kilt.yaml

--- a/runtimes/cloudformation/Makefile
+++ b/runtimes/cloudformation/Makefile
@@ -2,7 +2,7 @@ kilt.zip: cmd/handler/handler
 	cd cmd/handler/ && zip ../../kilt.zip ./handler
 
 cmd/handler/handler:
-	cd cmd/handler && GOOS=linux GOARCH=amd64 go build .
+	cd cmd/handler && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
 
 clean:
 	rm kilt.zip

--- a/utilities/launcher/Makefile
+++ b/utilities/launcher/Makefile
@@ -1,2 +1,2 @@
 launcher:
-	go build .
+	CGO_ENABLED=0 go build .

--- a/utilities/logshipper/Makefile
+++ b/utilities/logshipper/Makefile
@@ -1,2 +1,2 @@
 logshipper:
-	go build .
+	CGO_ENABLED=0 go build .

--- a/utilities/waitforever/Makefile
+++ b/utilities/waitforever/Makefile
@@ -1,2 +1,2 @@
 waitforever:
-	go build .
+	CGO_ENABLED=0 go build .


### PR DESCRIPTION
Signed-off-by: Radu Andries <radu.andries@sysdig.com>

**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

Binaries built with cgo enabled will not work without a libc in the container, making it hard to support containers from scratch. 


