### PR TITLE
Improve hints for scratch images

### DIFF
--- a/runtimes/cloudformation/cfnpatcher/entrypointinfo.go
+++ b/runtimes/cloudformation/cfnpatcher/entrypointinfo.go
@@ -2,8 +2,8 @@ package cfnpatcher
 
 import (
 	"fmt"
-	"github.com/Jeffail/gabs/v2"
 
+	"github.com/Jeffail/gabs/v2"
 	"github.com/google/go-containerregistry/pkg/crane"
 )
 
@@ -30,17 +30,14 @@ func GetConfigFromRepository(image string) (*PartialImageConfig,error) {
 				ic.Entrypoint = append(ic.Entrypoint, a)
 			}
 		}
-	}else{
-		return nil, fmt.Errorf("image %s does not have entrypoint specified in config - possibly broken config", image)
 	}
+
 	if cont.Exists("config", "Cmd") {
 		for _, v := range cont.S("config", "Cmd").Children() {
 			if a, ok := v.Data().(string); ok {
 				ic.Command = append(ic.Command, a)
 			}
 		}
-	}else{
-		return nil, fmt.Errorf("image %s does not have command specified in config - possibly broken config", image)
 	}
 
 	return ic, nil

--- a/runtimes/cloudformation/cfnpatcher/template.go
+++ b/runtimes/cloudformation/cfnpatcher/template.go
@@ -1,10 +1,12 @@
 package cfnpatcher
 
 import (
-	"github.com/Jeffail/gabs/v2"
-	"github.com/falcosecurity/kilt/pkg/kilt"
-	"github.com/rs/zerolog/log"
 	"os"
+
+	"github.com/Jeffail/gabs/v2"
+	"github.com/rs/zerolog/log"
+
+	"github.com/falcosecurity/kilt/pkg/kilt"
 )
 
 func extractContainerInfo(group *gabs.Container, groupName string, container *gabs.Container, configuration *Configuration) *kilt.TargetInfo {
@@ -23,8 +25,12 @@ func extractContainerInfo(group *gabs.Container, groupName string, container *ga
 			log.Warn().Str("image", info.Image).Err(err).Msg("could not retrieve metadata from repository")
 		}else{
 			if configuration.UseRepositoryHints {
-				info.EntryPoint = repoInfo.Entrypoint
-				info.Command = repoInfo.Command
+				if info.EntryPoint != nil {
+					info.EntryPoint = repoInfo.Entrypoint
+				}
+				if info.Command != nil {
+					info.Command = repoInfo.Command
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Some images have no command or entry point specified

Do not fail on images when cmd or entry point is nil, just
ignore the hint.

This fixes when image does not have an entry point or 
a command specified.

Signed-off-by: Radu Andries <radu.andries@sysdig.com>

**What type of PR is this?**

/kind bug


**Any specific area of the project related to this PR?**

/area cfn-runtime


