### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/release-kilt-runtimes.yml
+++ b/.github/workflows/release-kilt-runtimes.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
         id: go
       - name: Checkout Code
         uses: actions/checkout@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
 
 before:
   hooks:
-    - make -C runtimes/cloudformation kilt.zip
+    - make -C runtimes/cloudformation clean kilt.zip
     - make -C installer deps
     - go get github.com/markbates/pkger/cmd/pkger
     - go generate installer/generate.go

--- a/runtimes/cloudformation/Makefile
+++ b/runtimes/cloudformation/Makefile
@@ -5,7 +5,9 @@ cmd/handler/handler:
 	cd cmd/handler && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build .
 
 clean:
-	rm kilt.zip
+	rm kilt.zip || true
+	rm cmd/handler/handler || true
+	rm ../../kilt.zip || true
 
 
 .PHONY: clean


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

goreleaser builds now for macos arm as well. This means we need to use go 1.16. We also perform cleanup of lambda zip each build


