### PR TITLE
Initialize Command and Entrypoint when autodetecting them

### DIFF
--- a/runtimes/cloudformation/cfnpatcher/patcher.go
+++ b/runtimes/cloudformation/cfnpatcher/patcher.go
@@ -36,7 +36,7 @@ func applyTaskDefinitionPatch(ctx context.Context, name string, resource *gabs.C
 	if resource.Exists("Properties", "ContainerDefinitions") {
 		for _, container := range resource.S("Properties", "ContainerDefinitions").Children() {
 			info := extractContainerInfo(ctx, resource, name, container, configuration)
-			l.Info().Msgf("extracted info for container: %+v", info)
+			l.Info().Msgf("extracted info for container: %+v %+v", info.TargetInfo, info)
 			if shouldSkip(info.TargetInfo, configuration, hints) {
 				l.Info().Msgf("skipping container due to hints in tags")
 				continue

--- a/runtimes/cloudformation/cfnpatcher/template.go
+++ b/runtimes/cloudformation/cfnpatcher/template.go
@@ -59,9 +59,11 @@ func extractContainerInfo(ctx context.Context, group *gabs.Container, groupName 
 				l.Info().Str("image", info.Image).Msgf("extracted info from remote repository: %+v", repoInfo)
 				if repoInfo.Entrypoint != nil {
 					info.EntryPoint = repoInfo.Entrypoint
+					cfnInfo.EntryPoint = make([]*gabs.Container, len(info.EntryPoint))
 				}
 				if repoInfo.Command != nil {
 					info.Command = repoInfo.Command
+					cfnInfo.Command = make([]*gabs.Container, len(info.Command))
 				}
 			}
 		}
@@ -69,6 +71,7 @@ func extractContainerInfo(ctx context.Context, group *gabs.Container, groupName 
 
 	if container.Exists("EntryPoint") {
 		info.EntryPoint = make([]string, 0)
+		cfnInfo.EntryPoint = make([]*gabs.Container,0)
 		for _, arg := range container.S("EntryPoint").Children() {
 			passthrough, templateVal := GetValueFromTemplate(arg)
 			cfnInfo.EntryPoint = append(cfnInfo.EntryPoint, templateVal)
@@ -80,6 +83,7 @@ func extractContainerInfo(ctx context.Context, group *gabs.Container, groupName 
 
 	if container.Exists("Command") {
 		info.Command = make([]string, 0)
+		cfnInfo.Command = make([]*gabs.Container,0)
 		for _, arg := range container.S("Command").Children() {
 			passthrough, templateVal := GetValueFromTemplate(arg)
 			cfnInfo.Command = append(cfnInfo.Command, templateVal)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Currently autodetection of entrypoint and command is broken in 0.3.0


