### PR TITLE
Do not remove existing environment variables from template

### DIFF
--- a/pkg/hocon/fixtures/env_vars_input.json
+++ b/pkg/hocon/fixtures/env_vars_input.json
@@ -1,0 +1,10 @@
+{
+  "image": "busybox:latest",
+  "container_name": "test",
+  "container_group_name": "test_group",
+  "entry_point": ["/bin/stuff"],
+  "command": ["/bin/sh"],
+  "environment_variables": {
+    "PREEXISTING": "true"
+  }
+}

--- a/pkg/hocon/fixtures/kilt_env_vars.cfg
+++ b/pkg/hocon/fixtures/kilt_env_vars.cfg
@@ -1,0 +1,14 @@
+build {
+    entry_point: [/falco/pdig] ${?original.entry_point}
+    environment_variables: {
+        TEST: "true"
+    }
+    mount: [
+        {
+            name: "TestImage"
+            image: "falco/falco:latest"
+            volumes: ["/falco"]
+            entry_point: ["/falco/waitforever"]
+        }
+    ]
+}

--- a/pkg/hocon/hocon.go
+++ b/pkg/hocon/hocon.go
@@ -14,7 +14,6 @@ build {
 	entry_point: ${original.entry_point}
 	command: ${original.command}
 	image: ${original.image}
-	environment_variables: ${original.environment_variables}
 
 	mount: []
 }
@@ -45,10 +44,12 @@ func (k *KiltHocon) prepareFullStringConfig(info *kilt.TargetInfo) (*configurati
 	if err != nil {
 		return nil, fmt.Errorf("could not serialize info: %w", err)
 	}
+	rawEnv, _ := json.Marshal(info.EnvironmentVariables) // we would fail at info step
 
 	configString := "original:" + string(rawVars) + "\n" +
 		"config:" + k.config + "\n" +
-		defaults + k.definition
+		defaults + "build.environment_variables: " + string(rawEnv) + "\n" +
+		k.definition
 
 	return configuration.ParseString(configString), nil
 }

--- a/pkg/hocon/hocon_test.go
+++ b/pkg/hocon/hocon_test.go
@@ -40,3 +40,16 @@ func TestSimpleBuild(t *testing.T) {
 	assert.Equal(t, "true", b.EnvironmentVariables["TEST"])
 	assert.Equal(t, 1, len(b.Resources))
 }
+
+func TestEnvironmentVariables(t *testing.T) {
+	targetInfoString, _ := ioutil.ReadFile("./fixtures/env_vars_input.json")
+	definitionString, _ := ioutil.ReadFile("./fixtures/kilt_env_vars.cfg")
+
+	k := NewKiltHocon(string(definitionString))
+	info := new(kilt.TargetInfo)
+	_ = json.Unmarshal(targetInfoString, info)
+	b, _ := k.Build(info)
+
+	assert.Containsf(t, b.EnvironmentVariables, "PREEXISTING", "does not contain preexisting vars")
+	assert.Equal(t, "true", b.EnvironmentVariables["PREEXISTING"])
+}

--- a/runtimes/cloudformation/cfnpatcher/patcher.go
+++ b/runtimes/cloudformation/cfnpatcher/patcher.go
@@ -137,7 +137,7 @@ func applyContainerDefinitionPatch(ctx context.Context, container *gabs.Containe
 		}
 	}
 
-	if len(patch.EnvironmentVariables) > 0 {
+	if len(patch.EnvironmentVariables) > 0 && !container.Exists("Environment") {
 		_, err = container.Set([]interface{}{}, "Environment")
 
 		if err != nil {

--- a/runtimes/cloudformation/cfnpatcher/patcher.go
+++ b/runtimes/cloudformation/cfnpatcher/patcher.go
@@ -137,7 +137,7 @@ func applyContainerDefinitionPatch(ctx context.Context, container *gabs.Containe
 		}
 	}
 
-	if len(patch.EnvironmentVariables) > 0 && !container.Exists("Environment") {
+	if len(patch.EnvironmentVariables) > 0 {
 		_, err = container.Set([]interface{}{}, "Environment")
 
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently if patched task definition has environment variables not specified in kilt definition - they are dropped. This is not intended.


