### PR TITLE
fix: pdig build error

### DIFF
--- a/definitions/falco/Dockerfile
+++ b/definitions/falco/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:latest AS pdig-build
 RUN apk add g++ gcc cmake cmake make libtool elfutils-dev libelf-static linux-headers git
 RUN mkdir /source
 RUN git clone https://github.com/falcosecurity/pdig /source/pdig
-RUN git clone https://github.com/draios/sysdig /source/sysdig
+RUN git clone https://github.com/falcosecurity/libs /source/libs
 RUN mkdir /source/pdig/build
 RUN cd /source/pdig/build && cmake -DMUSL_OPTIMIZED_BUILD=True ..
 RUN cd /source/pdig/build && make


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind documentation

**Any specific area of the project related to this PR?**

/area build

**What this PR does / why we need it**:

The build of this Dockerfile throws an error without the `falcosecurity/libs` repository.
The `draios/sysdig` repository is not necessary.

The error was:
```
=> ERROR [pdig-build 7/8] RUN cd /source/pdig/build && cmake -DMUSL_OPTIMIZED_BUILD=True ..
  CMake Error at CMakeLists.txt:29 (add_executable):
    Cannot find source file:
    ../libs/driver/dynamic_params_table.c
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
