### PR TITLE
fix(cfnruntime): kilt patcher casing differences fix for ECS JSON

### DIFF
--- a/runtimes/cloudformation/cfnpatcher/cfn_test.go
+++ b/runtimes/cloudformation/cfnpatcher/cfn_test.go
@@ -32,6 +32,7 @@ var defaultTests = [...]string{
 	"patching/ref_env",
 	"patching/volumes_from",
 	"patching/tags",
+	"patching/ecs_tf",
 }
 
 const defaultConfig = `
@@ -95,9 +96,9 @@ func TestPatchingOptIn(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			runTest(t, testName, l.WithContext(context.Background()),
 				Configuration{
-					Kilt:         defaultConfig,
-					OptIn:        true,
-					RecipeConfig: "{}",
+					Kilt:               defaultConfig,
+					OptIn:              true,
+					RecipeConfig:       "{}",
 					UseRepositoryHints: false,
 				})
 		})
@@ -111,9 +112,9 @@ func TestPatching(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			runTest(t, testName, l.WithContext(context.Background()),
 				Configuration{
-					Kilt:         defaultConfig,
-					OptIn:        false,
-					RecipeConfig: "{}",
+					Kilt:               defaultConfig,
+					OptIn:              false,
+					RecipeConfig:       "{}",
 					UseRepositoryHints: false,
 				})
 		})

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/ecs_tf.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/ecs_tf.json
@@ -1,0 +1,41 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Dumb ECS Fargate Service",
+    "Parameters": {},
+    "Resources": {
+        "TestApp": {
+            "Properties": {
+                "ContainerDefinitions": [
+                    {
+                        "image": "quay.io/rehman0288/busyboxplus:latest",
+                        "name": "busybox",
+                        "entryPoint": [
+                        "watch",
+                        "-n60",
+                        "cat",
+                        "/etc/shadow"
+                        ],
+                        "Environment": [
+                        {
+                            "name": "pmet",
+                            "value": "temp"
+                        }
+                        ],
+                        "logConfiguration": {
+                        "logDriver": "awslogs",
+                        "options": {
+                            "awslogs-group": "test-log-group",
+                            "awslogs-region": "us-east-1",
+                            "awslogs-stream-prefix": "ecs"
+                        }
+                        }
+                    }
+                ],
+                "RequiresCompatibilities": [
+                    "FARGATE"
+                ]
+            },
+            "Type": "AWS::ECS::TaskDefinition"
+        }
+    }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/ecs_tf.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/ecs_tf.patched.json
@@ -1,0 +1,67 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Dumb ECS Fargate Service",
+    "Parameters": {
+    },
+    "Resources": {
+      "TestApp": {
+        "Properties": {
+          "ContainerDefinitions": [
+            {
+              "Command": [
+                "watch",
+                "-n60",
+                "cat",
+                "/etc/shadow"
+              ],
+              "EntryPoint": [
+                "/kilt/run",
+                "--",
+                ""
+              ],
+              "Environment": [
+                {
+                  "Name": "pmet",
+                  "Value": "temp"
+                }
+              ],
+              "Image": "quay.io/rehman0288/busyboxplus:latest",
+              "LinuxParameters": {
+                "Capabilities": {
+                  "Add": [
+                    "SYS_PTRACE"
+                  ]
+                }
+              },
+              "VolumesFrom": [
+                {
+                  "ReadOnly": true,
+                  "SourceContainer": "KiltImage"
+                }
+              ],
+              "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                  "awslogs-group": "test-log-group",
+                  "awslogs-region": "us-east-1",
+                  "awslogs-stream-prefix": "ecs"
+                }
+              },
+              "name": "busybox"
+            },
+            {
+              "EntryPoint": [
+                "/kilt/wait"
+              ],
+              "Image": "KILT:latest",
+              "Name": "KiltImage"
+            }
+          ],
+          "RequiresCompatibilities": [
+            "FARGATE"
+          ]
+        },
+        "Type": "AWS::ECS::TaskDefinition"
+      }
+    }
+  }

--- a/runtimes/cloudformation/cfnpatcher/patcher.go
+++ b/runtimes/cloudformation/cfnpatcher/patcher.go
@@ -85,7 +85,7 @@ func postPatchReplace(patched []string, original []string, parallel []*gabs.Cont
 	return value
 }
 
-func postPatchSelect(patched string, previous string, original *gabs.Container)  interface{} {
+func postPatchSelect(patched string, previous string, original *gabs.Container) interface{} {
 	if patched == previous && original != nil {
 		return original
 	}
@@ -107,6 +107,21 @@ func applyContainerDefinitionPatch(ctx context.Context, container *gabs.Containe
 		return fmt.Errorf("could not set Command: %w", err)
 	}
 
+	// This code block is used when parsing ECS JSON format
+	if container.Exists("image") {
+		err = container.Delete("image")
+		if err != nil {
+			return fmt.Errorf("could not delete image in the Container definition: %w", err)
+		}
+	}
+
+	// This code block is used when parsing ECS JSON format
+	if container.Exists("entryPoint") {
+		err = container.Delete("entryPoint")
+		if err != nil {
+			return fmt.Errorf("could not delete entryPoint in the Container definition: %w", err)
+		}
+	}
 
 	_, err = container.Set(postPatchSelect(patch.Image, cfnInfo.TargetInfo.Image, cfnInfo.Image), "Image")
 	if err != nil {
@@ -141,8 +156,8 @@ func applyContainerDefinitionPatch(ctx context.Context, container *gabs.Containe
 		_, err = container.Set([]interface{}{}, "Environment")
 
 		if err != nil {
-		return fmt.Errorf("could not add environment variable container: %w", err)
-	}
+			return fmt.Errorf("could not add environment variable container: %w", err)
+		}
 	}
 
 	for k, v := range patch.EnvironmentVariables {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
Bugfix PR to support ECS JSON casing differences while patching

/kind bug

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**
/area tests

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The current Kilt patcher requires Cloudformation JSON. This causes some issues when attempting to patch ECS JSON, due to the casing differences. This PR has modifications to allow for correct values of Entrypoint, Image, Command and Environment variables to be patched.

This PR also includes a lot of lint-suggested fixes.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

This is my first commit to the kilt repo. 
```release-note
This change is a bug fix for casing differences that occur in EntryPoint, Command, Image, and Environment variables when attempting to patch ECS JSON.
```