### PR TITLE
feat: support !Ref for tag values

### DIFF
--- a/runtimes/cloudformation/cfnpatcher/cfn_test.go
+++ b/runtimes/cloudformation/cfnpatcher/cfn_test.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
 
+	"github.com/Jeffail/gabs/v2"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
 	diff "github.com/yudai/gojsondiff"
 	"github.com/yudai/gojsondiff/formatter"
 )
@@ -20,18 +23,26 @@ var optInTests = [...]string{
 	"respect_ignores/opt_in_single_container",
 }
 
+var optPanicTests = [...]string{
+	"respect_ignores/panic_opt_exclude",
+	"respect_ignores/panic_opt_exclude_container",
+	"respect_ignores/panic_opt_include",
+	"respect_ignores/panic_opt_include_container",
+}
+
 var defaultTests = [...]string{
 	"respect_ignores/opt_out_default",
 	"respect_ignores/opt_out_ignored",
 	"respect_ignores/opt_out_ignore_single_container",
 
-	"patching/entrypoint",
 	"patching/command",
+	"patching/entrypoint",
 	"patching/ref",
 	"patching/ref_command",
 	"patching/ref_env",
-	"patching/volumes_from",
+	"patching/ref_tags",
 	"patching/tags",
+	"patching/volumes_from",
 }
 
 const defaultConfig = `
@@ -151,6 +162,160 @@ func TestPatchingForLogGroup(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			runTest(t, test.Name, l.WithContext(context.Background()), test.Config)
+		})
+	}
+}
+
+func TestOptTagPanic(t *testing.T) {
+	l := log.Output(zerolog.ConsoleWriter{Out: os.Stderr}).With().Caller().Logger()
+
+	for _, testName := range optPanicTests {
+		t.Run(testName, func(t *testing.T) {
+			defer func() { recover() }()
+
+			runTest(t, testName, l.WithContext(context.Background()),
+				Configuration{
+					Kilt:         defaultConfig,
+					OptIn:        true,
+					RecipeConfig: "{}",
+					UseRepositoryHints: false,
+				})
+		})
+	}
+}
+
+func TestIsFuncOptKey(t *testing.T) {
+ 	tests := []struct {
+		key string
+		out bool
+	}{
+		{
+			"kilt-ignore",
+			true,
+		},
+		{
+			"kilt-include",
+			true,
+		},
+		{
+			"kilt-ignore-containers",
+			true,
+		},
+		{
+			"kilt-include-containers",
+			true,
+		},
+		{
+			"so-long-and-thanks-for-all-the-fish",
+			false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.key, func(t *testing.T) {
+			assert.Equal(t, test.out, isOptTagKey(test.key), "OptIn/Out key not recognized")
+		})
+	}
+}
+
+func TestGetOptTags(t *testing.T) {
+ 	tests := []struct {
+		name     string
+		json     string
+		expected map[string]string
+	}{
+		{
+			name: `no-properties`,
+			json: `{
+"McGuffin": {
+	"Tags":[
+		{
+			"Key": "SoLong",
+			"Value": "AndThanksForAllTheFish"
+		}
+	]}
+}`,
+			expected: make(map[string]string),
+		},
+		{
+			name: `no-tags`,
+			json: `{
+"Properties": {
+	"Accio":[
+		{
+			"Key": "SoLong",
+			"Value": "AndThanksForAllTheFish"
+		}
+	]}
+}`,
+			expected: make(map[string]string),
+		},
+		{
+			name: `no-opt-tags`,
+			json: `{
+"Properties": {
+	"Tags":[
+		{
+			"Key": "SoLong",
+			"Value": "AndThanksForAllTheFish"
+		},
+		{
+			"Key": "TimeIsAnIllusion",
+			"Value": "LunchtimeDoublySo"
+		}
+	]}
+}`,
+			expected: make(map[string]string),
+		},
+		{
+			name: `all-opt-tags`,
+			json: `{
+"Properties": {
+	"Tags": [
+		{
+			"Key": "SoLong",
+			"Value": "AndThanksForAllTheFish"
+		},
+		{
+			"Key": "TimeIsAnIllusion",
+			"Value": "LunchtimeDoublySo"
+		},
+		{
+			"Key": "kilt-ignore",
+			"Value": "nanananananaBatman"
+		},
+		{
+			"Key": "kilt-include",
+			"Value": "gimmeGimmeGimmeFriedChicken"
+		},
+		{
+			"Key": "kilt-ignore-containers",
+			"Value": "expelliarmus"
+		},
+		{
+			"Key": "kilt-include-containers",
+			"Value": "accioContainer"
+		}
+	]}
+}`,
+			expected: map[string]string {
+				"kilt-ignore": "nanananananaBatman",
+				"kilt-include": "gimmeGimmeGimmeFriedChicken",
+				"kilt-ignore-containers": "expelliarmus",
+				"kilt-include-containers": "accioContainer",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			jsonParsed, err := gabs.ParseJSON([]byte(tc.json))
+			if err != nil {
+				panic(err)
+			}
+			mm := getOptTags(jsonParsed)
+			eq := reflect.DeepEqual(tc.expected, mm)
+			if !eq {
+				assert.Fail(t, "maps do not match")
+			}
 		})
 	}
 }

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/ref_tags.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/ref_tags.json
@@ -1,0 +1,29 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": {"Ref": "Parameter"}
+          },
+          {
+            "Key": "captured_tag",
+            "Value": "somearg"
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "busybox",
+            "Command": ["/bin/sh"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/ref_tags.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/ref_tags.patched.json
@@ -1,0 +1,56 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--",
+              "somearg"
+            ],
+            "Image": "busybox",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": [
+                  "SYS_PTRACE"
+                ]
+              }
+            },
+            "Name": "app",
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": {"Ref": "Parameter"}
+          },
+          {
+            "Key": "captured_tag",
+            "Value": "somearg"
+          }
+        ]
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_exclude.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_exclude.json
@@ -1,0 +1,35 @@
+{
+  "Resources": {
+    "willnotpatch": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kilt-exclude",
+            "Value": {
+              "Ref": "itisignored"
+            }
+          },
+          {
+            "Key": "kilt-ignore",
+            "Value": "ignoretagisignored"
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "busybox",
+            "EntryPoint": ["/bin/sh"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_exclude_container.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_exclude_container.json
@@ -1,0 +1,36 @@
+{
+  "Resources": {
+    "willpatch": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kilt-ignore-containers",
+            "Value": {
+              "Ref" : "nopatch"
+            }
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "busybox",
+            "EntryPoint": ["/bin/sh"]
+          },
+          {
+            "Name": "nopatch",
+            "Image": "busybox",
+            "EntryPoint": ["/bin/sh"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_include.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_include.json
@@ -1,0 +1,31 @@
+{
+  "Resources": {
+    "willpatch": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "kilt-include",
+            "Value": {
+              "Ref": "whatever"
+            }
+          },
+          {
+            "Key": "sometag",
+            "Value": "antani"
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "busybox",
+            "EntryPoint": ["/bin/sh"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_include_container.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/respect_ignores/panic_opt_include_container.json
@@ -1,0 +1,36 @@
+{
+  "Resources": {
+    "willpatch": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "kilt-include-containers",
+            "Value": {
+              "Ref": "app"
+            }
+          },
+          {
+            "Key": "sometag",
+            "Value": "antani"
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "busybox",
+            "EntryPoint": ["/bin/sh"]
+          },
+          {
+            "Name": "something-else",
+            "Image": "busybox",
+            "EntryPoint": ["/bin/sh"]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Francesco Racciatti <francesco.racciatti@sysdig.com>

**What type of PR is this?**
> Uncomment one (or more) /kind <> lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Currently, Kilt crashes when users provide `Ref` values for any tag below the TaskDefinition, due to OptIn/OptOut tag evaluation.

This PR supports `Ref` values in TaskDefinition's tags for any tag but OptIn/OptOut reserved keys:
 - `kilt-ignore`
 - `kilt-include`
 - `kilt-ignore-containers`
 - `kilt-include-containers`

**Special notes for your reviewer:**
NONE