### PR TITLE
fix: falco userspace ci

### DIFF
--- a/definitions/falco/Dockerfile
+++ b/definitions/falco/Dockerfile
@@ -6,7 +6,9 @@ FROM alpine:latest AS pdig-build
 RUN apk add g++ gcc cmake cmake make libtool elfutils-dev libelf-static linux-headers git
 RUN mkdir /source
 RUN git clone https://github.com/falcosecurity/pdig /source/pdig
-RUN git clone https://github.com/falcosecurity/libs /source/libs
+RUN git clone https://github.com/falcosecurity/libs /source/libs \
+    && cd /source/libs \
+    && git checkout 2258aba1b3f9e8f8b1a9e1af3a9f7a1eb6c1299c
 RUN mkdir /source/pdig/build
 RUN cd /source/pdig/build && cmake -DMUSL_OPTIMIZED_BUILD=True ..
 RUN cd /source/pdig/build && make

--- a/definitions/falco/Dockerfile
+++ b/definitions/falco/Dockerfile
@@ -13,7 +13,6 @@ RUN cd /source/pdig/build && make
 
 FROM scratch
 COPY --from=falco /usr/bin/falco /vendor/falco/bin/falco
-COPY --from=falco /usr/share/falco/lua /vendor/falco/share/lua
 COPY --from=falco /etc /vendor/falco/etc
 COPY --from=pdig-build /source/pdig/build/pdig /vendor/falco/bin/pdig
 COPY --from=kilt-utils /kilt/waitforever /vendor/falco/bin/waitforever


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes the build process of the Falco Userspace Image in the Kilt CI.

In [definitions/falco/Dockerfile](https://github.com/falcosecurity/kilt/blob/master/definitions/falco/Dockerfile) there are two issues:
1. Falco does not use Lua anymore
```Dockerfile
COPY --from=falco /usr/share/falco/lua /vendor/falco/share/lua
```
2. pdig was archived a while ago, but it relies on libs, and pdig and libs diverged too much
```shell
...
#0 0.714 CMake Error at CMakeLists.txt:29 (add_executable):
#0 0.714   Cannot find source file:
#0 0.714 
#0 0.714     ../libs/userspace/libscap/scap_udig.c
...
```

Even if we patch the pdig's `CMakeLists.txt` at build time via `sed`, we still have other compile errors we cannot easily fix:
```shell
...
#0 1.556 /source/pdig/pdig_compat.c: In function 'record_event':
#0 1.556 /source/pdig/pdig_compat.c:289:29: error: 'RING_BUF_SIZE' undeclared (first use in this function)
#0 1.556   289 |                 freespace = RING_BUF_SIZE + ttail - head - 1;
#0 1.556       |                             ^~~~~~~~~~~~~
...
#0 1.557 /source/pdig/pdig_compat.c:340:21: error: 'struct event_filler_arguments' has no member named 'cur_g_syscall_code_routing_table'
#0 1.557   340 |                 args.cur_g_syscall_code_routing_table = event_datap->event_info.syscall_data.cur_g_syscall_code_routing_table;
#0 1.557       |                     ^
...
```

To address the issues above, this PR:
 1. drops the lua dependency,
 2. checkouts the latest libs' compatible commit.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:


