### PR TITLE
build: fix goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
   hooks:
     - make -C runtimes/cloudformation clean kilt.zip
     - make -C installer deps
-    - go get github.com/markbates/pkger/cmd/pkger
+    - go install github.com/markbates/pkger/cmd/pkger@latest
     - go generate installer/generate.go
 builds:
   - env:

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -1,5 +1,5 @@
 installer: deps
-	go get github.com/markbates/pkger/cmd/pkger
+	go install github.com/markbates/pkger/cmd/pkger@latest
 	pkger -o cmd/kilt-installer
 	cd cmd/kilt-installer && CGO_ENABLED=0 go build .
 	@cp cmd/kilt-installer/kilt-installer kilt


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area build

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

This PR fixes the goreleaser step in `release-kilt-runtimes.yml`.
It uses `go install @latest` instead of `go get` outside the `installer` module.

```
Run goreleaser/goreleaser-action@v2
...
2022-11-07T14:27:55.3981879Z [1;91m  ⨯[0m [1mrelease failed after 24s[0m                 [1;91merror[0m=hook failed: go get github.com/markbates/pkger/cmd/pkger: exit status 1; output: go: go.mod file not found in current directory or any parent directory.
2022-11-07T14:27:55.3982690Z 	'go get' is no longer supported outside a module.
2022-11-07T14:27:55.3983220Z 	To build and install a command, use 'go install' with a version,
2022-11-07T14:27:55.3983706Z 	like 'go install example.com/cmd@latest'
2022-11-07T14:27:55.3984319Z 	For more information, see https://golang.org/doc/go-get-install-deprecation
2022-11-07T14:27:55.3984829Z 	or run 'go help get' or 'go help install'.
2022-11-07T14:27:55.3985071Z 
2022-11-07T14:27:55.4016956Z ##[error]The process '/opt/hostedtoolcache/goreleaser-action/1.12.3/x64/goreleaser' failed with exit code 1
```

**Special notes for your reviewer**:


