### PR TITLE
fix: base64 decode string

### DIFF
--- a/runtimes/cloudformation/config/base64.go
+++ b/runtimes/cloudformation/config/base64.go
@@ -6,8 +6,7 @@ import (
 )
 
 func FromBase64(payload string, decompress bool) string {
-	var data []byte
-	_, err := base64.StdEncoding.Decode(data, []byte(payload))
+	data, err := base64.StdEncoding.DecodeString(payload)
 
 	if err != nil {
 		panic(fmt.Errorf("could not decode base64: %w", err))

--- a/runtimes/cloudformation/config/base64_test.go
+++ b/runtimes/cloudformation/config/base64_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBase64(t *testing.T) {
+	tests := []struct {
+		decompress bool
+		plaintext  string
+		encoded    string
+
+	}{
+		{
+			decompress: false,
+			plaintext: `So long, and thanks for all the fish!`,
+			encoded:   `U28gbG9uZywgYW5kIHRoYW5rcyBmb3IgYWxsIHRoZSBmaXNoIQ==`,
+		},
+		{
+			decompress: false,
+			plaintext: `nanananananananaBatman!`,
+			encoded:   `bmFuYW5hbmFuYW5hbmFuYUJhdG1hbiE=`,
+		},
+		{
+			decompress: false,
+			plaintext: `{[(?!weird string!?)]`,
+			encoded:   `e1soPyF3ZWlyZCBzdHJpbmchPyld`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.plaintext, func(t *testing.T) {
+			encoded := base64.StdEncoding.EncodeToString([]byte(tc.plaintext))
+			assert.Equal(t, tc.encoded, encoded, "the encoded string does not match the expected value")
+
+			decoded := FromBase64(encoded, tc.decompress)
+			assert.Equal(t, tc.plaintext, decoded, "decoded and plaintext strings do not match")
+		})
+	}
+}

--- a/runtimes/cloudformation/go.mod
+++ b/runtimes/cloudformation/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.10.2 // indirect
 	github.com/rs/zerolog v1.19.0
 	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/stretchr/testify v1.6.1 // indirect
 	github.com/yudai/gojsondiff v1.0.0
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yudai/pp v2.0.1+incompatible // indirect

--- a/runtimes/cloudformation/go.sum
+++ b/runtimes/cloudformation/go.sum
@@ -267,6 +267,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Currently, `base64.go` crashes when decoding `base64` encoded strings because the length of `var data []byte`is zero.
```
panic: runtime error: index out of range [2] with length 0
--
goroutine 1 [running]:
encoding/base64.(*Encoding).decodeQuantum(0xc00011fdd8?, {0x0?, 0x400?, 0x0?}, {0xc000032c00?, 0x400?, 0xc000032c00?}, 0xc000032c00?)
/usr/lib/golang/src/encoding/base64/base64.go:360 +0x2b0
encoding/base64.(*Encoding).Decode(0xc00008a000, {0x0, 0x0, 0x0}, {0xc000032c00, 0x3b0, 0x400})
/usr/lib/golang/src/encoding/base64/base64.go:528 +0x565
github.com/falcosecurity/kilt/runtimes/cloudformation/config.FromBase64({0xc000032010?, 0xe?}, 0x0)
/usr/src/app/kilt/runtimes/cloudformation/config/base64.go:10 +0x59
```

This PR fixes the crash above and adds the related UTs.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:


