### PR TITLE
feat: allow recipe envars parameterization

### DIFF
--- a/runtimes/cloudformation/cfnpatcher/cfn.go
+++ b/runtimes/cloudformation/cfnpatcher/cfn.go
@@ -15,6 +15,7 @@ type Configuration struct {
 	RecipeConfig       string
 	UseRepositoryHints bool
 	LogGroup           string
+	ParameterizeEnvars bool
 }
 
 type InstrumentationHints struct {
@@ -71,6 +72,11 @@ func Patch(ctx context.Context, configuration *Configuration, fragment []byte) (
 	if err != nil {
 		l.Error().Err(err).Msg("failed to parse input fragment")
 		return nil, err
+	}
+
+	if configuration.ParameterizeEnvars {
+		l.Info().Msg("parameterizing recipe envars")
+		applyParametersPatch(ctx, template, configuration)
 	}
 
 	for name, resource := range template.S("Resources").ChildrenMap() {

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/parameterize_env_add.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/parameterize_env_add.json
@@ -1,0 +1,29 @@
+{
+  "Resources": {
+    "taskdef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kiltinclude",
+            "Value": "itisignored"
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "busybox",
+            "Command": ["/bin/sh"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/parameterize_env_add.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/parameterize_env_add.patched.json
@@ -1,0 +1,70 @@
+{
+  "Parameters": {
+    "soLongAndThanks": {
+      "Default": "ForAllTheFish",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--",
+              ""
+            ],
+            "Environment": [
+              {
+                "Name": "SO_LONG_AND_THANKS",
+                "Value": {
+                  "Ref": "soLongAndThanks"
+                }
+              }
+            ],
+            "Image": "busybox",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": [
+                  "SYS_PTRACE"
+                ]
+              }
+            },
+            "Name": "app",
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kiltinclude",
+            "Value": "itisignored"
+          }
+        ]
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/parameterize_env_merge.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/parameterize_env_merge.json
@@ -1,0 +1,41 @@
+{
+  "Parameters": {
+    "NAME": {
+      "Default": "Parameter",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "taskdef": {
+      "Type": "AWS::ECS::TaskDefinition",
+      "Properties": {
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kiltinclude",
+            "Value": "itisignored"
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Name": "app",
+            "Image": "busybox",
+            "Command": ["/bin/sh"],
+            "Environment": [
+              {
+                "Name": "NAME",
+                "Value": {"Ref": "Parameter"}
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/fixtures/patching/parameterize_env_merge.patched.json
+++ b/runtimes/cloudformation/cfnpatcher/fixtures/patching/parameterize_env_merge.patched.json
@@ -1,0 +1,80 @@
+{
+  "Parameters": {
+    "NAME": {
+      "Default": "Parameter",
+      "Type": "String"
+    },
+    "soLongAndThanks": {
+      "Default": "ForAllTheFish",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "taskdef": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh"
+            ],
+            "EntryPoint": [
+              "/kilt/run",
+              "--",
+              ""
+            ],
+            "Environment": [
+              {
+                "Name": "NAME",
+                "Value": {
+                  "Ref": "Parameter"
+                }
+              },
+              {
+                "Name": "SO_LONG_AND_THANKS",
+                "Value": {
+                  "Ref": "soLongAndThanks"
+                }
+              }
+            ],
+            "Image": "busybox",
+            "LinuxParameters": {
+              "Capabilities": {
+                "Add": [
+                  "SYS_PTRACE"
+                ]
+              }
+            },
+            "Name": "app",
+            "VolumesFrom": [
+              {
+                "ReadOnly": true,
+                "SourceContainer": "KiltImage"
+              }
+            ]
+          },
+          {
+            "EntryPoint": [
+              "/kilt/wait"
+            ],
+            "Image": "KILT:latest",
+            "Name": "KiltImage"
+          }
+        ],
+        "RequiresCompatibilities": [
+          "FARGATE"
+        ],
+        "Tags": [
+          {
+            "Key": "antani",
+            "Value": "sbiribuda"
+          },
+          {
+            "Key": "kiltinclude",
+            "Value": "itisignored"
+          }
+        ]
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}

--- a/runtimes/cloudformation/cfnpatcher/util.go
+++ b/runtimes/cloudformation/cfnpatcher/util.go
@@ -3,9 +3,26 @@ package cfnpatcher
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/Jeffail/gabs/v2"
 )
+
+var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9][^\W_]?`)
+
+func getParameterName(envarName string) string {
+	// Use the envar name if it does not contain any non-alphanumeric chars
+	if found := nonAlphanumericRegex.MatchString(envarName); !found {
+		return envarName
+	}
+
+	// Otherwise, try to make it more readable, e.g. MY_AWESOME_ENVAR becomes myAwesomeEnvar
+	parameterName := nonAlphanumericRegex.ReplaceAllStringFunc(strings.ToLower(envarName), func(str string) string {
+		return strings.ToUpper(str[1:])
+	})
+	return parameterName
+}
 
 func getOptTags(template *gabs.Container) map[string]string {
 	optTags := make(map[string]string)

--- a/runtimes/cloudformation/cmd/handler/main.go
+++ b/runtimes/cloudformation/cmd/handler/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 
 	"github.com/falcosecurity/kilt/runtimes/cloudformation/config"
 
@@ -74,6 +75,8 @@ func GetConfig() *cfnpatcher.Configuration {
 	recipeConfig := os.Getenv("KILT_RECIPE_CONFIG")
 	disableRepoHints := os.Getenv("KILT_DISABLE_REPO_HINTS")
 	logGroup := os.Getenv("KILT_LOG_GROUP")
+	parameterizeEnvars := os.Getenv("KILT_PARAMETERIZE_ENVARS")
+
 	var fullDefinition string
 	switch definitionType {
 	case config.S3:
@@ -97,6 +100,7 @@ func GetConfig() *cfnpatcher.Configuration {
 		RecipeConfig:       recipeConfig,
 		UseRepositoryHints: disableRepoHints == "",
 		LogGroup:           logGroup,
+		ParameterizeEnvars: strings.ToLower(parameterizeEnvars) == "true",
 	}
 
 	return configuration


### PR DESCRIPTION
Signed-off-by: Francesco Racciatti <francesco.racciatti@sysdig.com>

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind design

> /kind documentation

> /kind failing-test

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area build

> /area tests

> /area proposals

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
When patching a template, Kilt merges the envars of the recipe with those of the container(s).
However, when Kilt runs locally, the value of some envars could be unknown.
As a result, to init such envars, users would have to edit the resulting template before deploying it.

This PR adds the new option `KILT_PARAMETERIZE_ENVARS` to parameterize the envars of the recipe.

If `KILT_PARAMETERIZE_ENVARS` is enabled, Kilt will patch the template `Parameters` so that the envars of the recipe can be easily initialized at deployment time.

For example, if the recipe contains the following envars:
```
environment_variables: {
    "TimeIsAnIllusion": "LunchtimeDoublySo"
    "SO_LONG_AND_THANKS": "ForAllTheFish"
}
```
and the new option `KILT_PARAMETERIZE_ENVARS="true"`,

then, the envars of the recipe will be parameterized as follows:
```
Parameters:
    ...
    TimeIsAnIllusion:
        Default: "LunchtimeDoublySo"
        Type: String
    soLongAndThanks:
        Default: "ForAllTheFish"
        Type: String

...
Resources:
    TaskDefinition:
        ContainersDefinition
            MyContainer:
                ....
                Environment:
                    - Name: TimeIsAnIllusion
                       Value: !Ref TimeIsAnIllusion
                    - Name: SO_LONG_AND_THANKS
                       Value: !Ref soLongAndThanks
```
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:

Note that envar keys can include underscores, but CloudFormation parameter names [cannot](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-requirements).
> Each parameter must be given a logical name (also called logical ID), which must be alphanumeric

So, to make human-friendly parameter names out of envar keys, I decided to:
 - use the envar key if it does not contain underscores,
 - and camelCase the envar key if it does contain underscores.